### PR TITLE
WIP: Add Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vagrant
+salt-server.log
+salt/.ruby-version
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Currently only works on Debian-based systems. Tested with Salt 3004.
 
 # Provisioning
 
+Clone the repo:
+
+```
+git clone https://github.com/rsutton1/dotfiles.git
+```
+
 There are two options for provisioning: inside a VM or directly on the host.
 
 ## VM
@@ -41,6 +47,7 @@ Install Vagrant: https://www.vagrantup.com/downloads
 Then run:
 
 ```
+cd dotfiles
 vagrant up
 vagrant ssh -- -A # ssh forwarding for pushing code changes
 sudo salt-call state.apply # provision changes inside VM
@@ -60,7 +67,6 @@ sudo sh bootstrap-salt.sh -X stable 3004.2
 ### Commands
 
 ```
-$ git clone https://github.com/rsutton1/dotfiles.git
 $ cd dotfiles/salt
 $ sudo ./configure.sh # setup salt installation
 $ sudo salt-call state.apply test=true # show what Salt would do

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ complete solution.
 
 Currently only works on Debian-based systems. Tested with Salt 3004.
 
+# Provisioning
+
+There are two options for provisioning: inside a VM or directly on the host.
+
+## VM
+
+Install Vagrant: https://www.vagrantup.com/downloads
+
+Then run:
+
+```
+vagrant up
+vagrant ssh -- -A # ssh forwarding for pushing code changes
+sudo salt-call state.apply # provision changes inside VM
+```
+
+## Host
+
 ### Dependencies
 
 Salt 3004.X: download for your platform here https://repo.saltproject.io/
@@ -39,18 +57,19 @@ Using [salt-bootstrap](https://github.com/saltstack/salt-bootstrap#install-using
 sudo sh bootstrap-salt.sh -X stable 3004.2
 ```
 
-# Provisioning a new system
+### Commands
 
 ```
 $ git clone https://github.com/rsutton1/dotfiles.git
 $ cd dotfiles/salt
+$ sudo ./configure.sh # setup salt installation
 $ sudo salt-call state.apply test=true # show what Salt would do
 $ sudo salt-call state.apply # apply changes to your system
 ```
 
 # Save changes
 
-Once you've provisioned your system and made some local changes, here's how to
+Once you've provisioned your system and changed dotfiles, here's how to
 save them back into the repo.
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Saltstack ](https://saltproject.io/). Chezmoi is excellent for static dotfiles
 and Salt meets these goals for packages. By combining the two, it provides a
 complete solution.
 
-## Note
-
-Currently only works on Debian-based systems. Tested with Salt 3004.
-
 # Provisioning
 
 Clone the repo:
@@ -54,6 +50,8 @@ sudo salt-call state.apply # provision changes inside VM
 ```
 
 ## Host
+
+Currently only works on Debian-based systems.
 
 ### Dependencies
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,87 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # config.winssh.forward_agent = true
+  config.ssh.forward_agent = true
+  # config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key","~/.ssh/id_ed25519"]
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/focal64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "salt/files", "/srv/salt/"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+#  #
+   config.vm.provider "virtualbox" do |vb|
+     # Display the VirtualBox GUI when booting the machine
+     vb.gui = true
+
+     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+
+     # --boot<1-4> none|floppy|dvd|disk|net
+     vb.customize ["modifyvm", :id, "--boot1", "disk"]
+     vb.customize ["modifyvm", :id, "--boot2", "net"]
+#  #
+#  #   # Customize the amount of memory on the VM:
+#  #   vb.memory = "1024"
+   end
+
+#  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision :salt do |salt|
+    salt.masterless = true
+    salt.minion_config = "salt/bootstrap"
+    salt.run_highstate = true
+  end
+#  config.vm.provision :salt do |salt|
+#    salt.masterless = true
+#    salt.minion_config = "salt/system"
+#    salt.run_highstate = true
+#  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,12 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :salt do |salt|
     salt.masterless = true
     salt.minion_config = "salt/system"
-    salt.run_highstate = true
+    salt.run_highstate = false
   end
   config.vm.provision 'shell', path: 'salt/configure.sh'
-#  config.vm.provision :salt do |salt|
-#    salt.masterless = true
-#    salt.minion_config = "salt/system"
-#    salt.run_highstate = true
-#  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,9 +76,10 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision :salt do |salt|
     salt.masterless = true
-    salt.minion_config = "salt/bootstrap"
+    salt.minion_config = "salt/system"
     salt.run_highstate = true
   end
+  config.vm.provision 'shell', path: 'salt/configure.sh'
 #  config.vm.provision :salt do |salt|
 #    salt.masterless = true
 #    salt.minion_config = "salt/system"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder "salt/files", "/srv/salt/"
+  config.vm.synced_folder "salt/", "/srv/salt/"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/salt/bootstrap
+++ b/salt/bootstrap
@@ -1,0 +1,4 @@
+file_client: local
+file_roots:
+  base:
+    - /srv/salt/files/

--- a/salt/configure.sh
+++ b/salt/configure.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo salt-call state.apply pygit

--- a/salt/files/chezmoi.sls
+++ b/salt/files/chezmoi.sls
@@ -35,7 +35,7 @@ chezmoi_init:
 
 chezmoi_diff:
   cmd.run:
-    - name: sudo -u {{ user }} /usr/local/bin/chezmoi apply
+    - name: sudo -u {{ user }} /usr/local/bin/chezmoi apply --force
     - runas: {{ user }}
     - cwd: /home/{{ user }}
     - stateful:

--- a/salt/files/nvim.sls
+++ b/salt/files/nvim.sls
@@ -56,5 +56,6 @@ neovim_plugins_installed:
   cmd.run:
     - name: sudo -H -u {{ user }} {{ nvim_path }}/bin/nvim -es -u /home/{{ user }}/.config/nvim/init.vim -i NONE -c "PlugInstall" -c "qa"
     - require:
-      - cmd: neovim_installed
+      - neovim_installed
       - node-archive-install-file-symlink-node # for coc
+      - neovim_ag_installed

--- a/salt/files/pygit.sls
+++ b/salt/files/pygit.sls
@@ -1,0 +1,8 @@
+python3_pip:
+  pkg.installed:
+    - name: python3-pip
+pygit:
+  pip.installed:
+    - name: pygit2
+    - require:
+      - python3_pip

--- a/salt/system
+++ b/salt/system
@@ -1,0 +1,16 @@
+file_client: local
+fileserver_backend:
+  - roots
+  - gitfs
+
+gitfs_remotes:
+  - https://github.com/saltstack-formulas/docker-formula
+  - https://github.com/saltstack-formulas/node-formula
+
+root_dir: .
+file_roots:
+  base:
+    - files
+pillar_roots:
+  base:
+    - pillar

--- a/salt/system
+++ b/salt/system
@@ -7,10 +7,9 @@ gitfs_remotes:
   - https://github.com/saltstack-formulas/docker-formula
   - https://github.com/saltstack-formulas/node-formula
 
-root_dir: .
 file_roots:
   base:
-    - files
+    - /srv/salt/files
 pillar_roots:
   base:
-    - pillar
+    - /srv/salt/pillar


### PR DESCRIPTION
This allows Salt to provision inside a Vagrant VM when running `vagrant up` for the first time, or `vagrant provision` against an existing VM.